### PR TITLE
Fixed CoinJar::Address.list as per CoinJar::Transaction.list.

### DIFF
--- a/lib/coinjar/address.rb
+++ b/lib/coinjar/address.rb
@@ -14,7 +14,7 @@ module CoinJar
     end
     
     def self.list(offset = 0, limit = 100)
-      CoinJar.client.get("bitcoin_addresses", { offset: offset, limit: limit }).map { |p| self.new p[:bitcoin_address] }
+      CoinJar.client.get("bitcoin_addresses", { offset: offset, limit: limit })[:bitcoin_addresses].map { |p| self.new p }
     end
     
   end


### PR DESCRIPTION
A similar kind of fix as the transaction_fetch_fix branch merged recently.  This fix is as per the Transaction.list method.
